### PR TITLE
Env vars: implement OpenID Connect auth aswell

### DIFF
--- a/docker/fame.env.template
+++ b/docker/fame.env.template
@@ -8,3 +8,19 @@ MONGODB_PASSWORD=pass
 FAME_URL=http://fame_web:4200
 
 # FAME_GIT_SSH_KEY=  #Enter here the result of: awk '{printf "%s\\n", $0}' myprivatekey.key
+
+FAME_AUTHENTICATION_TYPE=user_passwod
+
+# LDAP_URI=ldap://dc.ad-domain.com:389
+# LDAP_USER=username@ad-domain.com
+# LDAP_PASSWORD=password
+# LDAP_FILTER_EMAIL=(&(objectCategory=Person)(sAMAccountName=*)(mail={}))
+# LDAP_FILTER_DN=OU=People,DC=ad-domain,DC=com
+
+# OIDC_AUTHORIZE_ENDPOINT=https://opURL/oauth2/authorize
+# OIDC_TOKEN_ENDPOINT=https://opURL/oauth2/access_token
+# OIDC_USERINFO_ENDPOINT=https://opURL/oauth2/userinfo
+# OIDC_JWK_URI_ENDPOINT=https://opURL/oauth2/connect/jwk_uri
+# OIDC_REQUESTED_SCOPES=openid profile fame
+# OIDC_CLIENT_ID=11111111-1111-1111-1111-111111111111
+# OIDC_CLIENT_SECRET=ARandomClientSecret

--- a/utils/install.py
+++ b/utils/install.py
@@ -141,6 +141,14 @@ def define_authentication(context):
     context['ldap_filter_email'] = os.getenv("LDAP_FILTER_EMAIL", "")
     context['ldap_filter_dn'] = os.getenv("LDAP_FILTER_DN", "")
 
+    context['oidc_authorize_endpoint'] = os.getenv("OIDC_AUTHORIZE_ENDPOINT", "")
+    context['oidc_token_endpoint'] = os.getenv("OIDC_TOKEN_ENDPOINT", "")
+    context['oidc_userinfo_endpoint'] = os.getenv("OIDC_USERINFO_ENDPOINT", "")
+    context['oidc_jwk_uri_endpoint'] = os.getenv("OIDC_JWK_URI_ENDPOINT", "")
+    context['oidc_requested_scopes'] = os.getenv("OIDC_REQUESTED_SCOPES", "")
+    context['oidc_client_id'] = os.getenv("OIDC_CLIENT_ID", "")
+    context['oidc_client_secret'] = os.getenv("OIDC_CLIENT_SECRET", "")
+
     context['auth'] = os.getenv("FAME_AUTHENTICATION_TYPE", "user_password")
 
 

--- a/utils/templates/local_fame.conf
+++ b/utils/templates/local_fame.conf
@@ -12,9 +12,19 @@ auth={{auth}}
 secret_key = {{secret_key}}
 fame_url = {{fame_url}}
 max_inactivity_time = 5m
-
+{% if ldap_uri %}
 ldap_uri = {{ldap_uri}}
 ldap_user = {{ldap_user}}
 ldap_password = {{ldap_password}}
 ldap_filter_email = {{ldap_filter_email}}
 ldap_filter_dn = {{ldap_filter_dn}}
+{% endif %}
+{% if oidc_authorize_endpoint %}
+oidc_authorize_endpoint = {{oidc_authorize_endpoint}}
+oidc_token_endpoint = {{oidc_token_endpoint}}
+oidc_userinfo_endpoint = {{oidc_userinfo_endpoint}}
+oidc_jwk_uri_endpoint = {{oidc_jwk_uri_endpoint}}
+oidc_requested_scopes = {{oidc_requested_scopes}}
+oidc_client_id = {{oidc_client_id}}
+oidc_client_secret = {{oidc_client_secret}}
+{% endif %}


### PR DESCRIPTION
I'm extending `define_authentication()` to OpenID Connect auth in addition to LDAP/AD auth.

In the future, `fame.conf` should maybe be converted to a volume, but that's a too big rework for now. 